### PR TITLE
Fix string layout determination

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,11 +39,10 @@ pub use use_after_free::use_after_free;
 pub fn construct_fake_string(ptr: *mut u8, cap: usize, len: usize) -> String {
 	let sentinel_string = crate::transmute::<_, String>([0usize, 1usize, 2usize]);
 
-	let fields = [ptr as usize, cap, len];
 	let mut actual_buf = [0usize; 3];
-	actual_buf[0] = fields[sentinel_string.as_ptr() as usize];
-	actual_buf[1] = fields[sentinel_string.capacity()];
-	actual_buf[2] = fields[sentinel_string.len()];
+	actual_buf[sentinel_string.as_ptr() as usize] = ptr as usize;
+	actual_buf[sentinel_string.capacity()] = cap;
+	actual_buf[sentinel_string.len()] = len;
 
 	std::mem::forget(sentinel_string);
 


### PR DESCRIPTION
The current `construct_fake_string()` layout determination code is wrong (but luckily works when the layout is `[ptr, cap, len]`!)

Suppose the real layout is `[len, ptr, cap]`. Then
```
sentinel_string.as_ptr() as usize == 1
sentinel_string.capacity() == 2
sentinel_string.len() == 0
```
Which would cause the previous code to create a string with layout `[fields[1], fields[2], fields[0]] == [cap, len, ptr]` when it's supposed to create `[len, ptr, cap]`.

The new code would execute
```
actual_buf[1] = ptr;
actual_buf[2] = cap;
actual_buf[0] = len;
```
Which would correctly create a string with layout `[len, ptr, cap]`.