### PR TITLE
Use built-in constant instead of a magic number

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,7 +70,7 @@ pub fn give_up<T: 'static>() -> Box<T> {
 	};
 
 	for _ in 0..size {
-		v.push((rng.rand_u32() & Into::<u32>::into(u8::MAX)) as u8);
+		v.push((rng.rand_u32() & u32::from(u8::MAX)) as u8);
 	}
 
 	crate::transmute(v.into_boxed_slice())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,7 +70,7 @@ pub fn give_up<T: 'static>() -> Box<T> {
 	};
 
 	for _ in 0..size {
-		v.push((rng.rand_u32() % 256) as u8);
+		v.push((rng.rand_u32() & Into::<u32>::into(u8::MAX)) as u8);
 	}
 
 	crate::transmute(v.into_boxed_slice())


### PR DESCRIPTION
In job-security providing functions, it is critically important that they be fully in line with best coding practices. Hence, instead of using a well-known(ish!) hardcoded power of two, use u8::MAX to truncate the u32 into a u8.