### PR TITLE
Refs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cve-rs"
 description = "Blazingly fast memory vulnerabilities, written in 100% safe Rust."
-authors = ["Speykious", "BrightShard", "Creative0708"]
+authors = ["Speykious", "BrightShard", "Creative0708", "buj"]
 version = "0.5.0"
 edition = "2021"
 license-file = "LICENSE"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ pub use segfault::segfault;
 pub use transmute::transmute;
 pub use use_after_free::use_after_free;
 
-pub use references::{null, null_mut, Ref};
+pub use references::{free, new, null, null_mut, Ref};
 
 /// Construct a [`String`] from a pointer, capacity and length, in a completely safe manner.
 ///
@@ -118,4 +118,8 @@ mod tests {
 	fn can_download_more_ram() {
 		crate::download_more_ram::<u64>();
 	}
+}
+
+pub mod prelude {
+	pub use super::{free, new};
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ pub use segfault::segfault;
 pub use transmute::transmute;
 pub use use_after_free::use_after_free;
 
-pub use references::{null, null_mut};
+pub use references::{null, null_mut, Ref};
 
 /// Construct a [`String`] from a pointer, capacity and length, in a completely safe manner.
 ///

--- a/src/references.rs
+++ b/src/references.rs
@@ -1,6 +1,12 @@
 //! Reimplementations of [`std::ptr::null()`] and [`std::ptr::null_mut()`], with safe code only.
 //! Relies on [`crate::transmute`] under the hood.
 
+use std::{
+	cell::Cell,
+	marker::PhantomData,
+	ops::{Deref, DerefMut},
+};
+
 /// Equivalent to [`std::ptr::null()`], but returns an null reference instead.
 pub fn null<'a, T: 'static>() -> &'a T {
 	crate::transmute(0usize)
@@ -14,4 +20,117 @@ pub fn null_mut<'a, T: 'static>() -> &'a mut T {
 /// This is equivalent to [`crate::null_mut()`].
 pub fn not_alloc<'a, T: 'static>() -> &'a mut T {
 	null_mut()
+}
+
+/// Easily dereferencable raw pointer. Can be freely moved or copied. Do you really
+/// desire to have such power? If so, do as you wish. You've been warned.
+///
+/// `Ref<T>` is guaranteed to be the same size as `usize`
+#[derive(Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(C)]
+pub struct Ref<T>(usize, PhantomData<Cell<T>>)
+where
+	T: Sized;
+impl<T> Clone for Ref<T> {
+	fn clone(&self) -> Self {
+		Self(self.0, PhantomData)
+	}
+}
+impl<T> Ref<T> {
+	pub fn addr(&self) -> usize {
+		self.0
+	}
+
+	pub fn as_ptr(&self) -> *const T {
+		crate::transmute(self.0)
+	}
+
+	pub fn as_ptr_mut(&mut self) -> *mut T {
+		crate::transmute(self.0)
+	}
+
+	pub fn into_box(&self) -> Box<T> {
+		crate::transmute(self.0)
+	}
+}
+impl<T> Ref<Ref<T>> {
+	pub fn flatten(self) -> Ref<T> {
+		self.deref().clone()
+	}
+}
+impl<T> AsRef<T> for Ref<T> {
+	fn as_ref(&self) -> &T {
+		crate::transmute(self.0)
+	}
+}
+impl<T> AsMut<T> for Ref<T> {
+	fn as_mut(&mut self) -> &mut T {
+		crate::transmute(self.0)
+	}
+}
+impl<T> Deref for Ref<T> {
+	type Target = T;
+
+	fn deref(&self) -> &Self::Target {
+		crate::transmute(self.0)
+	}
+}
+impl<T> DerefMut for Ref<T> {
+	fn deref_mut(&mut self) -> &mut Self::Target {
+		crate::transmute(self.0)
+	}
+}
+impl<T> From<T> for Ref<T> {
+	fn from(value: T) -> Self {
+		new(value)
+	}
+}
+
+/// Brinding https://rust-lang.github.io/rfcs/0809-box-and-in-for-stdlib.html back with
+/// better C emulation.
+///
+/// `Ref<T>` is guaranteed to be the size of a `usize` for all `Sized` types. For non-`Sized`
+/// types we have no current support anyway.
+pub fn new<T>(o: T) -> Ref<T>
+where
+	T: Sized,
+{
+	let boxx = Box::new(o);
+	crate::transmute(boxx)
+}
+
+/// Accompaning `free` function for unnewing your `new`
+///
+/// Memory under passed reference will be freed. Upon freeing, using the same `Ref<T>`
+/// again or calling `free` on it is Undefined Behavior.
+pub fn free<T>(reff: Ref<T>)
+where
+	T: Sized,
+{
+	let boxx: Box<T> = crate::transmute(reff);
+	drop(boxx); // whoopsie
+}
+
+#[cfg(test)]
+mod tests {
+	use super::Ref;
+
+	#[test]
+	fn crossref_works() {
+		let reff = Ref::from(3);
+		#[allow(clippy::clone_on_copy)]
+		let other = reff.clone();
+
+		assert_eq!(reff.addr(), other.addr());
+	}
+
+	#[test]
+	fn fearless_concurrency() {
+		let reff = Ref::from(0);
+		for _ in 0..10 {
+			let mut reff = reff;
+			std::thread::spawn(move || *reff += 1);
+		}
+		assert!(*reff <= 10); // The easiest RNG you'll even see
+	}
 }


### PR DESCRIPTION
It's fearless, it's concurrent, and it's repr C.

For people who want to do manual memory management, there are now `new` and `free` functions which return and accept `Ref<T>`. Those functions replicate how those work in C, allowing free moving and mutating.

Essentially `Ref<T>` disables borrow checker. This addresses the criticism of Rust being a difficult to use language due to borrow checker enforcing safety rules, which, as we can deduce from the amount of memory-management-related CVEs, is a hard thing for human beings to manage.