### PR TITLE
Experiment with `transmute` without `black_box`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,6 @@ oorandom = { version = "11.1.3", optional = true }
 [dev-dependencies]
 criterion = "0.5.1"
 
-[profile.dev]
-debug = false
-
 [features]
 default = []
 download-more-ram = ["ureq"]

--- a/src/transmute.rs
+++ b/src/transmute.rs
@@ -20,37 +20,38 @@
 /// Finally, we take the `Box<A>`, interpreted as a `Box<B>`, out of the dangling reference and we've transmuted our data!
 ///
 /// # Safety
+///
 /// lol
 ///
 pub fn transmute<A, B>(obj: A) -> B {
-	use std::hint::black_box;
-
-	// The layout of `DummyEnum` is approximately
-	// DummyEnum {
-	//     is_a_or_b: u8,
-	//     data: usize,
-	// }
-	// Note that `data` is shared between `DummyEnum::A` and `DummyEnum::B`.
-	// This should hopefully be more reliable than spamming the stack with a value and hoping the memory
-	// is placed correctly by the compiler.
+	/// The layout of `DummyEnum` is approximately:
+	///
+	/// ```ignore
+	/// DummyEnum {
+	///     is_a_or_b: u8,
+	///     data: usize,
+	/// }
+	/// ```
+	///
+	/// Note that `data` is shared between `DummyEnum::A` and `DummyEnum::B`.
+	/// This should hopefully be more reliable than spamming the stack with a value and hoping the memory
+	/// is placed correctly by the compiler.
 	enum DummyEnum<A, B> {
 		A(Option<Box<A>>),
 		B(Option<Box<B>>),
 	}
 
-	#[inline(never)]
 	fn transmute_inner<A, B>(dummy: &mut DummyEnum<A, B>, obj: A) -> B {
 		let DummyEnum::B(ref_to_b) = dummy else {
 			unreachable!()
 		};
 		let ref_to_b = crate::lifetime_expansion::expand_mut(ref_to_b);
 		*dummy = DummyEnum::A(Some(Box::new(obj)));
-		black_box(dummy);
 
 		*ref_to_b.take().unwrap()
 	}
 
-	transmute_inner(black_box(&mut DummyEnum::B(None)), obj)
+	transmute_inner(&mut DummyEnum::B(None), obj)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
I want to see if it's possible. The original reason for using `black_box` and `#[inline(never)]` everywhere is because we used stack spamming and that the stack was extremely unpredictable. Since we're not doing that anymore, we might not need all of this compiler hint witchery (for anything other than `use_after_free` which doesn't use `transmute`).