### PR TITLE
fix expand & expand_mut in nightly

### DIFF
--- a/src/lifetime_expansion.rs
+++ b/src/lifetime_expansion.rs
@@ -44,7 +44,7 @@ pub fn lifetime_translator_mut<'a, 'b, T: ?Sized>(
 ///
 /// Safety? What's that?
 pub fn expand<'a, 'b, T: ?Sized>(x: &'a T) -> &'b T {
-	let f: fn(_, &'a T) -> &'b T = lifetime_translator;
+	let f: for<'x> fn(_, &'x T) -> &'b T = lifetime_translator;
 	f(STATIC_UNIT, x)
 }
 
@@ -54,7 +54,7 @@ pub fn expand<'a, 'b, T: ?Sized>(x: &'a T) -> &'b T {
 ///
 /// Safety? What's that?
 pub fn expand_mut<'a, 'b, T: ?Sized>(x: &'a mut T) -> &'b mut T {
-	let f: fn(_, &'a mut T) -> &'b mut T = lifetime_translator_mut;
+	let f: for<'x> fn(_, &'x mut T) -> &'b mut T = lifetime_translator_mut;
 	f(STATIC_UNIT, x)
 }
 


### PR DESCRIPTION
`cve-rs` does not compile in nightly due to https://github.com/rust-lang/rust/pull/129021 and this change will be landed in Rust 1.83. This PR fixes it.